### PR TITLE
package.json: fix peer deps and add type=module

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,18 @@
     "less": "^4.1.3",
     "less-loader": "^11.1.0",
     "pinia": "^2.0.32",
+    "vue": "^3",
     "vue-slider-component": "^4.1.0-beta.7",
     "vue3-popper": "^1.5.0"
   },
   "devDependencies": {
     "@types/xml": "^1.0.8",
-    "nuxt": "^3.2.2"
+    "css-loader": "^6",
+    "esbuild-loader": "^3",
+    "nuxt": "^3.2.2",
+    "postcss-loader": "^7",
+    "vue-loader": "^17",
+    "webpack": "^5.0.0"
   },
   "name": "@wwtelescope/constellations-frontend",
   "private": true,
@@ -30,5 +36,6 @@
     "preview": "nuxt preview",
     "start": "nuxt start"
   },
+  "type": "module",
   "version": "0.0.0-dev.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1859,14 +1859,20 @@ __metadata:
     "@wwtelescope/engine-helpers": ^0.11.1
     "@wwtelescope/engine-pinia": ^0.3.1
     "@wwtelescope/engine-types": ^0.6.4
+    css-loader: ^6
+    esbuild-loader: ^3
     femtotween: ^2.0.3
     keycloak-js: ^21.0.0
     less: ^4.1.3
     less-loader: ^11.1.0
     nuxt: ^3.2.2
     pinia: ^2.0.32
+    postcss-loader: ^7
+    vue: ^3
+    vue-loader: ^17
     vue-slider-component: ^4.1.0-beta.7
     vue3-popper: ^1.5.0
+    webpack: ^5.0.0
   languageName: unknown
   linkType: soft
 
@@ -2799,7 +2805,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css-loader@npm:^6.7.3":
+"css-loader@npm:^6, css-loader@npm:^6.7.3":
   version: 6.7.3
   resolution: "css-loader@npm:6.7.3"
   dependencies:
@@ -3300,7 +3306,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-loader@npm:^3.0.0":
+"esbuild-loader@npm:^3, esbuild-loader@npm:^3.0.0":
   version: 3.0.1
   resolution: "esbuild-loader@npm:3.0.1"
   dependencies:
@@ -6034,7 +6040,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-loader@npm:^7.0.2":
+"postcss-loader@npm:^7, postcss-loader@npm:^7.0.2":
   version: 7.0.2
   resolution: "postcss-loader@npm:7.0.2"
   dependencies:
@@ -7746,7 +7752,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vue-loader@npm:^17.0.1":
+"vue-loader@npm:^17, vue-loader@npm:^17.0.1":
   version: 17.0.1
   resolution: "vue-loader@npm:17.0.1"
   dependencies:
@@ -7907,6 +7913,43 @@ __metadata:
   version: 0.5.0
   resolution: "webpack-virtual-modules@npm:0.5.0"
   checksum: 22b59257b55c89d11ae295b588b683ee9fdf3aeb591bc7b6f88ac1d69cb63f4fcb507666ea986866dfae161a1fa534ad6fb4e2ea91bbcd0a6d454368d7d4c64b
+  languageName: node
+  linkType: hard
+
+"webpack@npm:^5.0.0":
+  version: 5.76.1
+  resolution: "webpack@npm:5.76.1"
+  dependencies:
+    "@types/eslint-scope": ^3.7.3
+    "@types/estree": ^0.0.51
+    "@webassemblyjs/ast": 1.11.1
+    "@webassemblyjs/wasm-edit": 1.11.1
+    "@webassemblyjs/wasm-parser": 1.11.1
+    acorn: ^8.7.1
+    acorn-import-assertions: ^1.7.6
+    browserslist: ^4.14.5
+    chrome-trace-event: ^1.0.2
+    enhanced-resolve: ^5.10.0
+    es-module-lexer: ^0.9.0
+    eslint-scope: 5.1.1
+    events: ^3.2.0
+    glob-to-regexp: ^0.4.1
+    graceful-fs: ^4.2.9
+    json-parse-even-better-errors: ^2.3.1
+    loader-runner: ^4.2.0
+    mime-types: ^2.1.27
+    neo-async: ^2.6.2
+    schema-utils: ^3.1.0
+    tapable: ^2.1.1
+    terser-webpack-plugin: ^5.1.3
+    watchpack: ^2.4.0
+    webpack-sources: ^3.2.3
+  peerDependenciesMeta:
+    webpack-cli:
+      optional: true
+  bin:
+    webpack: bin/webpack.js
+  checksum: b01fe0bc2dbca0e10d290ddb0bf81e807a031de48028176e2b21afd696b4d3f25ab9accdad888ef4a1f7c7f4d41f13d5bf2395b7653fdf3e5e3dafa54e56dab2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
It looks like this may be necessary to get the server running in Azure. We have an error:

```
2023-03-13T20:08:51.703497664Z $ nuxt start
2023-03-13T20:08:51.832100245Z (node:91) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
2023-03-13T20:08:51.832152345Z (Use `node --trace-warnings ...` to show where the warning was created)
2023-03-13T20:08:51.835885027Z /home/site/wwwroot/node_modules/.bin/nuxt:2
2023-03-13T20:08:51.835954626Z import 'nuxi/cli'
2023-03-13T20:08:51.835966026Z ^^^^^^
2023-03-13T20:08:51.836008126Z
2023-03-13T20:08:51.836015726Z SyntaxError: Cannot use import statement outside a module
```