### PR TITLE
nuxt.config.ts: keycloak URL setting should be public

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -13,6 +13,8 @@ export default defineNuxtConfig({
   },
   builder: "webpack",
   runtimeConfig: {
-    keycloakUrl: "http://localhost:8080/"
+    public: {
+      keycloakUrl: "http://localhost:8080/"
+    }
   }
 });


### PR DESCRIPTION
The client does need to know where to send the browser, after all.