### PR TITLE
components/Feed.vue: avoid mixed-content warnings

### DIFF
--- a/components/Feed.vue
+++ b/components/Feed.vue
@@ -97,7 +97,7 @@ export default defineNuxtComponent({
     log(x: any) { console.log(x); },
     async loadItems(page: number): Promise<Item[]> {
       //const url = `http://${nuxtConfig.apiUrl}/data?page=${page}&limit=${this.pageSize}`;
-      const url = "http://data1.wwtassets.org/packages/2022/07_jwst/jwst_first_v2.wtml";
+      const url = "https://data1.wwtassets.org/packages/2022/07_jwst/jwst_first_v2.wtml";
       const store = this.$engineStore(this.$pinia);
       const folder = await store.loadImageCollection({
         url: url,


### PR DESCRIPTION
This doesn't show up in localhost testing, but on a live system, there are complaints due to this `http://` URL. This should all go away soon with a real data backend, but might as well straighten things out here.