### PR TITLE
On first setup, start the camera at the initial scene target

### DIFF
--- a/stores/constellations.ts
+++ b/stores/constellations.ts
@@ -5,6 +5,7 @@ import { SceneDisplayInfoT } from "../utils/types";
 export interface WWTConstellationsPiniaState {
   loggedIn: boolean;
   showWWT: boolean;
+  viewNeedsInitialization: boolean;
   desiredScene: SceneDisplayInfoT | null;
 };
 
@@ -12,6 +13,7 @@ export const useConstellationsStore = defineStore('wwt-constellations', {
   state: (): WWTConstellationsPiniaState => ({
     loggedIn: false,
     showWWT: true,
+    viewNeedsInitialization: true,
     desiredScene: null,
   })
 });


### PR DESCRIPTION
Instead of slewing over from the galactic center to wherever our first image happens to be, start at the location of the first image. This speeds things up.

We might potentially want to tweak the details of how this is done, but this is an improvement, I think.