### PR TITLE
Added WWT links to menu

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -26,18 +26,28 @@
             now. -->
           <ClientOnly>
             <n-drawer v-model:show="drawer" :width="502" style="max-width: 70%;" :placement="placement" aria-label="Drawer">
-              <n-drawer-content>
+              <n-drawer-content header-style="justify-content:center">
                 <template #header>
-                  <n-space :align="'center'" size="small">
+                  <n-space align="center">
                     <img :src="require('/assets/images/wwtlogo.png')" style="width: 24px;" alt="World Wide Telescope logo" />
                     WorldWide Telescope
                   </n-space>
                 </template>
-                <template #footer>
-                  <n-button @click="logInOut">
-                    {{ loggedIn ? 'Log out' : 'Log in' }}
-                  </n-button>
-                </template>
+                <n-button
+                  v-for="menuItem in menuItems"
+                  text
+                  tag="a"
+                  :href=menuItem.url
+                  target="_blank"
+                  class="menu-item"
+                >
+                  {{menuItem.name}}
+                </n-button>
+              <template #footer>
+                <n-button @click="logInOut">
+                  {{ loggedIn ? 'Log out' : 'Log in' }}
+                </n-button>
+              </template>
               </n-drawer-content>
             </n-drawer>
           </ClientOnly>
@@ -81,6 +91,19 @@ const { $keycloak } = useNuxtApp();
 
 const drawer = ref(false)
 const placement = ref<DrawerPlacement>('left')
+const menuItems: Array<MenuItem> = [
+  {name: "About WWT", url: "https://worldwidetelescope.org/about/"},
+  {name: "Acknowledgements", url: "https://worldwidetelescope.org/about/acknowledgments/"},
+  {name: "Privacy Policy", url: "#"},
+  {name: "Terms of Use", url: "https://worldwidetelescope.org/terms/"},
+  {name: "WWT Home", url: "https://worldwidetelescope.org/home/"},
+  {name: "WWT Webclient", url: "https://worldwidetelescope.org/webclient/"},
+]
+interface MenuItem {
+  name: string,
+  url: string
+}
+
 
 function logInOut() {
   if (!process.client) {
@@ -133,4 +156,11 @@ function logInOut() {
    * to make sure that it doesn't overlap the header. */
   padding-top: 32px;
 }
+
+.menu-item {
+  font-size: 1.2rem;
+  width: 100%;
+  padding: 10px 0px;
+}
+
 </style>


### PR DESCRIPTION
Added links to acknowledgments, terms, etc. I've left the Privacy policy link is still empty, as I think this page hasn't been created yet.

I've horizontally centered the menu items as they looked silly with so small items left justified in this large menu. As a consequence, I also centered the WWT text and logo above. I guess we could also consider shrinking the menu, especially if you would rather have left justified text.