### PR TITLE
Log scene shares

### DIFF
--- a/components/ShareButton.vue
+++ b/components/ShareButton.vue
@@ -10,7 +10,9 @@
                 <n-space justify="space-around" size="large">
                     <ShareNetwork v-for="network in networks" :network="network.network" :key="network.network"
                         :url="sharing.url" :title="sharing.title" :description="sharing.description"
-                        :hashtags="sharing.hashtags" :twitterUser="sharing.twitterUser" style="text-decoration: none;">
+                        :hashtags="sharing.hashtags" :twitterUser="sharing.twitterUser" style="text-decoration: none;"
+                        @open="recordShare(network.network)"
+                      >
                         <n-space :align="'center'" vertical>
                             <n-avatar :style="{ backgroundColor: network.color }" strong circle>
                                 <n-icon size="20">
@@ -29,8 +31,8 @@
             <template #footer>
                 <div class="url-prompt">Or send the following URL:</div>
                 <n-space :align="'center'" horizontal class="sharing-url-container">
-                    <span class="sharing-url" tabindex="0" @keyup.enter="copyURL">{{ sharing.url }}</span>
-                    <n-button aria-label="Copy URL to clipboard" @click="copyURL" @keyup.enter="copyURL">
+                    <span class="sharing-url" tabindex="0" @keyup.enter="onCopy">{{ sharing.url }}</span>
+                    <n-button aria-label="Copy URL to clipboard" @click="onCopy" @keyup.enter="onCopy">
                         <n-icon size="18">
                             <ContentCopyOutlined />
                         </n-icon>
@@ -52,6 +54,8 @@ import {
     NAvatar,
     NSpace
 } from "~/utils/fixnaive.mjs";
+
+const { $backendCall } = useNuxtApp();
 
 const notification = useNotification();
 
@@ -91,6 +95,18 @@ async function copyURL() {
     } catch (e: any) {
         notification.error({ content: `Failed to copy link: ${e}`, duration: 3000 });
     }
+}
+
+function recordShare(type: string) {
+  const id = props.url.split("/").pop();
+  if (id) {
+    addShare($backendCall, id, type);
+  }
+}
+
+function onCopy() {
+  copyURL();
+  recordShare("copy");
 }
 </script>
 

--- a/utils/apis.ts
+++ b/utils/apis.ts
@@ -661,6 +661,19 @@ export async function removeLike(fetcher: $Fetch, id: string): Promise<boolean> 
   });
 }
 
+export async function addShare(fetcher: $Fetch, id: string, type: string): Promise<boolean> {
+  return fetcher(`/scene/${id}/shares/${type}`, { method: 'POST', credentials: 'include', cache: 'no-store' }).then((data) => {
+    checkForError(data);
+    const maybe = SceneInteractionResponse.decode(data);
+
+    if (isLeft(maybe)) {
+      throw new Error(`POST /scenes/shares: API response did not match schema: ${PathReporter.report(maybe).join("\n")}`);
+    }
+
+    return maybe.right.success;
+  });
+}
+
 export async function initializeSession(fetcher: $Fetch): Promise<void> {
   return fetcher(`/session/init`, { method: 'POST', credentials: 'include' }).then((data) => {
     checkForError(data);


### PR DESCRIPTION
This PR adds functionality to log screen shares, using the new API endpoint added in https://github.com/WorldWideTelescope/wwt-constellations-backend/pull/28. The UI currently supports a few types of sharing - three social networks (Facebook, Twitter, and LinkedIn), sharing by email, or a direct link copy. For the social networks, the "share" is recorded when the sharing popup is opened - I didn't see any way from the `vue-social-sharing` docs to find when the user _actually_ shares the scene, so hopefully this gets us close enough. Their docs mention a `change` event that fires when one popup closes another, but from my testing I could have multiple popups open at once, and the `open` event fired for each one. If anyone else has a different experience I'm glad to revise.

For email and direct link share, the event is fired when the relevant button is clicked. Again, there's nothing to indicate that the user actually followed through on those actions, but hopefully this is a decent proxy for that.
