### PR TITLE
Make sharing information reactive

### DIFF
--- a/components/ShareButton.vue
+++ b/components/ShareButton.vue
@@ -64,13 +64,15 @@ const props = defineProps<{
 
 const showModal = ref(false);
 
-const sharing = {
+const sharing = computed(() => {
+  return {
     url: props.url,
     title: props.title,
     description: props.description,
     hashtags: 'WorldWideTelescope',
     twitterUser: 'WWTelescope'
-};
+  }
+});
 
 const modalTitle = computed(() => {
     return `Share @${props.handle}’s post`;


### PR DESCRIPTION
I noticed that currently, the sharing information doesn't update when one changes scenes (an easy way to see this is to look at the URL to copy). The reason for this is because `sharing` in the share button isn't reactive - it's just a regular object based on this initial props. This PR updates `sharing` to be a computed property based on the current value of the props.