### PR TITLE
Neighbor scene arrows

### DIFF
--- a/components/MainOverlay.vue
+++ b/components/MainOverlay.vue
@@ -375,10 +375,11 @@ watch(fullPageContainerRef, () => {
 });
 
 
-function updateArrowVisibility(threshold=0.05) {
+function updateArrowVisibility() {
   const scene = desiredScene.value;
-  if (!showNeighborArrows.value && scene) {
-    const place = scene.place
+  if (!isMovingToScene.value && !showNeighborArrows.value && scene) {
+    const place = scene.place;
+    const threshold = (wwt_zoom_deg.value / 60) * 0.05;
     if (distance(wwt_ra_rad.value, wwt_dec_rad.value, place.ra_rad, place.dec_rad) > threshold) {
       showNeighborArrows.value = true;
     }

--- a/components/MainOverlay.vue
+++ b/components/MainOverlay.vue
@@ -91,6 +91,8 @@ import {
   KeyboardArrowRightFilled,
 } from "@vicons/material";
 
+import { distance } from "@wwtelescope/astro";
+
 import { useConstellationsStore } from "~/stores/constellations";
 import { GetHandleResponseT, GetSceneResponseT } from "~/utils/apis";
 import { SceneDisplayInfoT, SkymapSceneInfo } from "~/utils/types";
@@ -172,7 +174,7 @@ const contextScenes = computed<ContextSceneInfo[]>(() => {
   }
 });
 
-const showNeighborArrows = ref(true);
+const showNeighborArrows = ref(false);
 
 const neighborScenes = computedAsync<SceneDisplayInfoT[]>(async () => {
   const scene = desiredScene.value;
@@ -370,6 +372,24 @@ watch(fullPageContainerRef, () => {
     scrollTo(timelineIndex.value);
     recenter();
   }
+});
+
+
+function updateArrowVisibility(threshold=0.05) {
+  const scene = desiredScene.value;
+  if (!showNeighborArrows.value && scene) {
+    const place = scene.place
+    if (distance(wwt_ra_rad.value, wwt_dec_rad.value, place.ra_rad, place.dec_rad) > threshold) {
+      showNeighborArrows.value = true;
+    }
+  }
+}
+
+watch(wwt_ra_rad, () => updateArrowVisibility()); 
+watch(wwt_dec_rad, () => updateArrowVisibility()); 
+
+watch(desiredScene, () => {
+  showNeighborArrows.value = false;
 });
 
 

--- a/components/MainOverlay.vue
+++ b/components/MainOverlay.vue
@@ -214,8 +214,9 @@ function neighborArrowStyle(scene: SceneDisplayInfoT): Record<string, any> {
     // in the range [0, 1]
     // The four intersections happen at t0 = +/-tx, +/-ty, but obviously only one of each pair will
     // be positive, so we can take the absolute value.
-    let x = -100;  // offscreen
-    let y = -100;
+    let x = 0;
+    let y = 0;
+    let visible = false;
     const tx = Math.abs(1 / (1 - (2 * scenePoint.x / window.innerWidth)));
     const ty = Math.abs(1 / (1 - (2 * scenePoint.y / window.innerHeight)));
     const ts = [tx, ty].filter(t => t >= 0 && t <= 1).sort();
@@ -223,18 +224,21 @@ function neighborArrowStyle(scene: SceneDisplayInfoT): Record<string, any> {
       const t = ts[0];
       x = Math.round(((1 - t) * window.innerWidth / 2) + t * scenePoint.x);
       y = Math.round(((1 - t) * window.innerHeight / 2) + t * scenePoint.y);
+      visible = true;
     }
 
-    x = Math.min(x, window.innerWidth - 30);
-    y = Math.min(y, window.innerHeight - 30);
+    // Clamp to be inside screen bounds
+    x = Math.max(Math.min(x, window.innerWidth - 40), 5);
+    y = Math.max(Math.min(y, window.innerHeight - 40), 5);
 
     return {
       transform: `rotate(${angle}rad)`,
       left: `${x}px`,
       top: `${y}px`,
+      visibility: visible ? 'visible' : 'hidden',
     };
   } catch (error) {
-    return { left: "-100px", right: "-100px" };
+    return { visibility: 'hidden' };
   }
 }
 
@@ -735,7 +739,7 @@ watchEffect(() => {
 }
 
 .neighbor-arrow {
-  position: absolute;
+  position: fixed;
   pointer-events: auto;
   padding: 0px;
 }

--- a/components/MainOverlay.vue
+++ b/components/MainOverlay.vue
@@ -796,15 +796,15 @@ watchEffect(() => {
 }
 
 @keyframes arrow-color-cycle {
-  8%, 25% {
+  16.7%, 50% {
     color: rgb(191, 243, 226);
   }
 
-  17% {
+  33% {
     color: #7fe7c4;
   }
 
-  33%, 100% {
+  66%, 100% {
     color: white;
   }
 }

--- a/components/MainOverlay.vue
+++ b/components/MainOverlay.vue
@@ -746,5 +746,6 @@ watchEffect(() => {
   position: fixed;
   pointer-events: auto;
   padding: 0px;
+  z-index: -1000;
 }
 </style>

--- a/components/MainOverlay.vue
+++ b/components/MainOverlay.vue
@@ -5,11 +5,11 @@
       <ClientOnly>
         <n-button
           v-if="showNeighborArrows"
-          v-for="scene in neighborScenes"
+          v-for="neighbor in neighborScenes"
           class="neighbor-arrow"
           :bordered="false"
-          @click="() => desiredScene = scene"
-          :style="neighborArrowStyle(scene)"
+          @click="() => constellationsStore.setupForSingleScene(neighbor)"
+          :style="neighborArrowStyle(neighbor)"
         >
           <n-icon size="30">
             <DoubleArrowRound />
@@ -176,18 +176,18 @@ const contextScenes = computed<ContextSceneInfo[]>(() => {
 
 const showNeighborArrows = ref(false);
 
-const neighborScenes = computedAsync<SceneDisplayInfoT[]>(async () => {
+const neighborScenes = computedAsync<GetSceneResponseT[]>(async () => {
   const scene = desiredScene.value;
   if (scene === null) {
     return [];
   }
   const place = scene.place;
   const cell = await getTessellationCell($backendCall, "global", place.ra_rad, place.dec_rad);
-  const neighbors: SceneDisplayInfoT[] = [];
-  for (const scene_id of cell.neighbors) {
-    const scene = await getScene($backendCall, scene_id);
-    if (scene !== null) {
-      neighbors.push(scene);
+  const neighbors: GetSceneResponseT[] = [];
+  for (const neighbor_id of cell.neighbors) {
+    const neighbor = await getScene($backendCall, neighbor_id);
+    if (neighbor !== null) {
+      neighbors.push(neighbor);
     }
   }
   return neighbors;

--- a/components/MainOverlay.vue
+++ b/components/MainOverlay.vue
@@ -9,8 +9,23 @@
         @click="() => constellationsStore.setupForSingleScene(neighbor)"
         :style="neighborArrowStyle(neighbor)"
       >
-        <n-icon size="30">
-          <DoubleArrowRound />
+        <n-icon size="30" color="white">
+          <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1080" height="1080" viewBox="0 0 1080 1080" xml:space="preserve">
+            <g transform="matrix(1 0 0 1 540 540)" id="5e37fbc9-afa3-4ee7-9700-3bde04719136"  >
+            </g>
+            <g transform="matrix(1 0 0 1 540 540)" id="3b68765a-11c4-4d1d-a495-a1bdf884d74f"  >
+            <rect style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: currentColor; fill-rule: nonzero; opacity: 1; visibility: hidden;" vector-effect="non-scaling-stroke"  x="-540" y="-540" rx="0" ry="0" width="1080" height="1080" />
+            </g>
+            <g transform="matrix(45 0 0 45 842.74 540)"  >
+            <path style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: currentColor; fill-rule: nonzero; opacity: 1;" vector-effect="non-scaling-stroke"  transform=" translate(-16.5, -12)" d="M 20.08 11.42 L 16.04 5.77 C 15.7 5.289999999999999 15.149999999999999 5 14.559999999999999 5 C 13.069999999999999 5 12.209999999999999 6.68 13.069999999999999 7.890000000000001 L 16 12 L 13.07 16.11 C 12.200000000000001 17.32 13.07 19 14.56 19 C 15.15 19 15.71 18.71 16.05 18.23 L 20.09 12.58 C 20.33 12.23 20.33 11.77 20.08 11.42 z" stroke-linecap="round" />
+            </g>
+            <g transform="matrix(45 0 0 45 527.74 540)"  >
+            <path style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: currentColor; fill-rule: nonzero; opacity: 1;" vector-effect="non-scaling-stroke"  transform=" translate(-9.5, -12)" d="M 13.08 11.42 L 9.05 5.77 C 8.7 5.29 8.15 5 7.56 5 C 6.07 5 5.2 6.68 6.07 7.89 L 9 12 L 6.07 16.11 C 5.2 17.32 6.07 19 7.56 19 C 8.15 19 8.709999999999999 18.71 9.049999999999999 18.23 L 13.09 12.58 C 13.33 12.23 13.33 11.77 13.08 11.42 z" stroke-linecap="round" />
+            </g>
+            <g transform="matrix(45 0 0 45 216.65 540)"  >
+            <path style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: currentColor; fill-rule: nonzero; opacity: 1;" vector-effect="non-scaling-stroke"  transform=" translate(-9.5, -12)" d="M 13.08 11.42 L 9.05 5.77 C 8.7 5.29 8.15 5 7.56 5 C 6.07 5 5.2 6.68 6.07 7.89 L 9 12 L 6.07 16.11 C 5.2 17.32 6.07 19 7.56 19 C 8.15 19 8.709999999999999 18.71 9.049999999999999 18.23 L 13.09 12.58 C 13.33 12.23 13.33 11.77 13.08 11.42 z" stroke-linecap="round" />
+            </g>
+            </svg>
         </n-icon>
       </n-button>
     </ClientOnly>
@@ -780,10 +795,45 @@ watchEffect(() => {
   pointer-events: all;
 }
 
+@keyframes arrow-color-cycle {
+  8%, 25% {
+    color: rgb(191, 243, 226);
+  }
+
+  17% {
+    color: #7fe7c4;
+  }
+
+  33%, 100% {
+    color: white;
+  }
+}
+
 .neighbor-arrow {
   position: fixed;
   pointer-events: auto;
   padding: 0px;
   z-index: -1000;
+
+  &:hover svg {
+    g {
+      animation: arrow-color-cycle;
+      animation-duration: 0.45s;
+      animation-iteration-count: infinite;
+    }
+
+    g:nth-child(3) {
+      animation-delay: 0.3s;
+    }
+
+    g:nth-child(4) {
+      animation-delay: 0.15s;
+    }
+
+    g:nth-child(5) {
+      animation-delay: 0s;
+    }
+  }
+
 }
 </style>

--- a/components/MainOverlay.vue
+++ b/components/MainOverlay.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="feed-root" :class="{ 'disable-pe': isExploreMode }" ref="feedRootRef" @mousemove="onMouseMove">
+  <div id="feed-root" :class="{ 'disable-pe': isExploreMode }" ref="feedRootRef">
     <!-- Desktop -->
     <template v-if="!isMobile">
       <ClientOnly>
@@ -191,6 +191,10 @@ const neighborScenes = computedAsync<SceneDisplayInfoT[]>(async () => {
   return neighbors;
 });
 
+// The calculations here assume that the WWT view takes up the entire screen
+// and that, because of this, the arrows want to live on the side of the screen.
+// If this is ever NOT the case, one could rework this by making the appropriate
+// affine transformation into the screen coordinate space of the WWT canvas.
 function neighborArrowStyle(scene: SceneDisplayInfoT): Record<string, any> {
   try {
     const currentPoint = engineStore.findScreenPointForRADec({ ra: wwt_ra_rad.value * R2D, dec: wwt_dec_rad.value * R2D });

--- a/utils/apis.ts
+++ b/utils/apis.ts
@@ -14,6 +14,8 @@ import {
   SceneContentHydrated,
   SceneCreationInfoT,
   ScenePreviews,
+  TessellationCell,
+  TessellationCellT
 } from "./types";
 
 function checkForError(item: any) {
@@ -701,4 +703,19 @@ export async function initializeSession(fetcher: $Fetch): Promise<void> {
   return fetcher(`/session/init`, { method: 'POST', credentials: 'include' }).then((data) => {
     checkForError(data);
   });
+}
+
+
+// Endpoint: GET /tessellations/cell
+
+export async function getTessellationCell(fetcher: $Fetch, tessellationName: string, raRad: number, decRad: number): Promise<TessellationCellT> {
+  const data = await fetcher(`/tessellations/${tessellationName}/cell`, { query: { ra: raRad, dec: decRad } });
+  checkForError(data);
+  const maybe = TessellationCell.decode(data);
+
+  if (isLeft(maybe)) {
+    throw new Error(`GET /tessellation/cell: API response did not match schema ${PathReporter.report(maybe).join("\n")}`);
+  }
+
+  return maybe.right;
 }

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -127,6 +127,17 @@ export interface SkymapSceneInfo {
   content: SceneContentHydratedT;
 }
 
+export const TessellationCell = t.type({
+  neighbors: t.array(t.string),
+  location: t.type({
+    ra: t.number,
+    dec: t.number,
+  }),
+  scene_id: t.string
+});
+
+export type TessellationCellT = t.TypeOf<typeof TessellationCell>;
+
 // Older types, potentially to be removed:
 
 export interface FitsColorMaps {


### PR DESCRIPTION
This PR contains an implementation of arrow buttons that will take the user to the current scene's neighbors in the global tessellation. This is still a bit rough, but the basic ideas are here. Basically, these arrows point towards the relevant scene, and will move around the edge of the screen to be on the line between their scene and the current camera position. I'm posting this as a draft so that it can be experimented with as we discuss options.

The main things that I think need sorting out are:
- When do we want these active?
  - We could do something along the same lines as the "reset view" button in the scene panel, and detect when the RA/Dec have moved some set amount away from the current scene location. The issue there is that a condition like that would be zoom-sensitive, but maybe that's fine.
  - We could also look for if the user has drag-moved since they came to the current scene. Possibly a bit trickier since we generally let any pointer events fall through to the WWT canvas, but I'm sure it could be done.

- I gave these arrows a very low z-index so that they'll slide behind other UI elements. I assume that's what we want?

- What do we want these to look like? I grabbed an arrow icon from the same icon set that we use in the scene panel, but maybe we want something more interesting? Since the particular scene is known, we could even use the scene thumbnail, or something.