### PR TITLE
ci/azure-deployment.yml: deploy to prod

### DIFF
--- a/ci/azure-deployment.yml
+++ b/ci/azure-deployment.yml
@@ -16,7 +16,13 @@ jobs:
 # Deployment jobs that should only happen on updates to the main branch.
 
 - ${{ if parameters.isMainDev }}:
-  - job: deploy_dev
+  # Currently (2023 October) we're deploying to prod from the main branch, since
+  # we're launching the service and will want to iterate rapidly. And we're
+  # probably going to tear down the dev environment unless we find a way to make
+  # it much cheaper to run. But ideally we'd deploy to a dev environment and
+  # only push to prod in Cranko releases, or whatever.
+
+  - job: deploy_prod
     pool:
       vmImage: ubuntu-latest
     variables:
@@ -27,11 +33,11 @@ jobs:
     # Custom startup command needed to work around module-loading issue related
     # to disappearance of symlinks in the Zip-based package
     - task: AzureWebApp@1
-      displayName: Deploy app to dev environment
+      displayName: Deploy app to prod environment
       inputs:
         azureSubscription: 'aas@wwtadmindotnetfoundation'
         appType: webAppLinux
-        appName: wwtdev-cxfe
+        appName: wwtprod-cxfe
         runtimeStack: 'NODE|18-lts'
         package: $(Pipeline.Workspace)/app-package/app-package-$(Build.BuildId).zip
         startUpCommand: node node_modules/nuxt/bin/nuxt.mjs start


### PR DESCRIPTION
Counterpart to WorldWideTelescope/wwt-constellations-backend#35.