### PR TITLE
Some QoL improvements for features interface

### DIFF
--- a/layouts/admin.vue
+++ b/layouts/admin.vue
@@ -10,6 +10,10 @@
 </template>
 
 <style lang="less">
+.n-config-provider {
+  overflow-y: scroll;
+}
+
 #admin-root {
   pointer-events: all;
   margin: 15px;

--- a/pages/_cxadmin/features.vue
+++ b/pages/_cxadmin/features.vue
@@ -12,6 +12,10 @@
           <n-modal
             v-model:show="showAddFeatureModal"
             title="Add a feature"
+            :on-after-leave="() => {
+              addFeatureSceneID = '';
+              addFeatureTime = Date.now();
+            }"
           >
             <n-card
               class="add-feature-card"
@@ -30,7 +34,12 @@
                 type="datetime"
               >
               </n-date-picker>
-              <n-button @click="addFeature(addFeatureSceneID, addFeatureTime)">Add feature</n-button>
+              <n-button
+                @click="addFeature(addFeatureSceneID, addFeatureTime)"
+                :disabled="addFeatureSceneID.length === 0"
+              >
+                Add feature
+              </n-button>
             </n-card>
           </n-modal>
           <n-calendar
@@ -129,6 +138,7 @@
             size="large"
             role="dialog"
             aria-modal="true"
+            :on-after-leave="addToQueueSceneID = ''"
           >
             <n-card>
               <n-input
@@ -138,7 +148,12 @@
               >
               </n-input>
               <div class="button-row">
-                <n-button @click="() => addSceneToQueue(addToQueueSceneID)">Add to queue</n-button>
+                <n-button
+                  @click="() => addSceneToQueue(addToQueueSceneID)"
+                  :disabled="addToQueueSceneID.length === 0"
+                >
+                  Add to queue
+                </n-button>
               </div>
             </n-card>
           </n-modal>

--- a/pages/_cxadmin/features.vue
+++ b/pages/_cxadmin/features.vue
@@ -346,6 +346,7 @@ async function addSceneToQueue(sceneID: string) {
   try {
     await updateFeatureQueue(fetcher, queueToTry); 
     queue.value.push(scene);
+    showAddQueueSceneModal.value = false;
     notification.success({ content: "Scene added to front of queue.", duration: 3000 });
   } catch (err) {
     notification.error({ content: "Error adding scene to queue.", duration: 3000 }); 


### PR DESCRIPTION
This PR makes a few small quality of life improvements to the scene features interface:
* Fix the issue with the inability to scroll mentioned in https://github.com/WorldWideTelescope/wwt-constellations-frontend/pull/70#issuecomment-2004944364. This was actually a problem at the level of the admin layout, but the window has to be somewhat small for the superuser view to need scrolling. I only enabled vertical scrolling since I don't really see horizontal scrolling being an issue.
* Close the modal after a scene is successfully added to a queue.
* Clear the scene ID values in the modals for adding features and adding a scene to the queue.
* Disable the buttons in the modals if the text field is empty.