### PR TITLE
Change superuser page to more general admin page

### DIFF
--- a/utils/apis.ts
+++ b/utils/apis.ts
@@ -314,7 +314,7 @@ export async function handleStats(fetcher: $Fetch, handle: string): Promise<Hand
 
 // Endpoint: POST /handle/:handle
 //
-// This is an undocumented superuser-only API, for now.
+// This is an undocumented admin-only API, for now.
 
 export const HandleCreateRequest = S.struct({
   display_name: S.string,


### PR DESCRIPTION
This is the frontend companion to https://github.com/WorldWideTelescope/wwt-constellations-backend/pull/45. This PR changes the "superuser" page to be a more generic "admin" page that shows the current user's Keycloak roles and only displays the UI elements for actions that they're allowed to take.